### PR TITLE
課題2-3 注文履歴および注文詳細画面の追加 (Issue/14)

### DIFF
--- a/www/conf/const.php
+++ b/www/conf/const.php
@@ -19,6 +19,7 @@ define('LOGIN_URL', '/login.php');
 define('LOGOUT_URL', '/logout.php');
 define('HOME_URL', '/index.php');
 define('CART_URL', '/cart.php');
+define('ORDER_URL', '/order.php');
 define('FINISH_URL', '/finish.php');
 define('ADMIN_URL', '/admin.php');
 

--- a/www/html/order.php
+++ b/www/html/order.php
@@ -1,0 +1,26 @@
+<?php
+require_once '../conf/const.php';
+require_once MODEL_PATH . 'functions.php';
+require_once MODEL_PATH . 'user.php';
+require_once MODEL_PATH . 'order.php';
+
+session_start();
+
+if(is_logined() === false){
+  redirect_to(LOGIN_URL);
+}
+
+$db = get_db_connect();
+$user = get_login_user($db);
+
+$orders = get_order_history($db, $user);
+$order_details = get_order_detail($db, $user);
+
+$total_price = array();
+foreach($order_details as $order_detail){
+  $total_price[$order_detail['order_id']] += $order_detail['price'] * $order_detail['quantity'];
+}
+
+/* トークンの生成 */
+$token = get_csrf_token();
+include_once VIEW_PATH . 'order_view.php';

--- a/www/html/order_detail.php
+++ b/www/html/order_detail.php
@@ -1,0 +1,27 @@
+<?php
+require_once '../conf/const.php';
+require_once MODEL_PATH . 'functions.php';
+require_once MODEL_PATH . 'user.php';
+require_once MODEL_PATH . 'order.php';
+
+session_start();
+
+/* トークンの照合 */
+collation_csrf_token(get_post('token'), ORDER_URL);
+
+if(is_logined() === false){
+  redirect_to(LOGIN_URL);
+}
+
+$db = get_db_connect();
+$user = get_login_user($db);
+
+$order_id = get_post('order_id');
+$created = get_post('created');
+$total_price = get_post('total_price');
+
+$order_details = get_order_detail_display($db, $order_id);
+
+/* トークンの生成 */
+$token = get_csrf_token();
+include_once VIEW_PATH . 'order_detail_view.php';

--- a/www/model/user.php
+++ b/www/model/user.php
@@ -114,6 +114,6 @@ function insert_user($db, $name, $password){
 
   /* $name, $passwordをPDOStatement::execute用の配列に格納 */
   $params = array(':name' => $name, ':password' => $password);
-  return execute_query($db, $sql);
+  return execute_query($db, $sql, $params);
 }
 

--- a/www/view/order_detail_view.php
+++ b/www/view/order_detail_view.php
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <?php include VIEW_PATH . 'templates/head.php'; ?>
+  <title>注文詳細</title>
+</head>
+<body>
+  <?php include VIEW_PATH . 'templates/header_logined.php'; ?>
+  <h1>注文詳細</h1>
+  <ul>
+    <li>注文番号: <?php print($order_id); ?></li>
+    <li>購入日時: <?php print($created); ?></li>
+    <li>合計金額: <?php print(number_format($total_price)); ?>円</li>
+  </ul>
+  <div class="container">
+
+    <?php include VIEW_PATH . 'templates/messages.php'; ?>
+
+    <?php if(count($order_details) > 0){ ?>    
+      <table class="table table-bordered">
+        <thead class="thead-light">
+          <tr>
+            <th>商品名</th>
+            <th>購入価格</th>
+            <th>購入数</th>
+            <th>小計</th>
+          </tr>
+        </thead>
+        <tbody>
+          <?php foreach($order_details as $order_detail){ ?>
+          <tr>
+            <td><?php print($order_detail['name']); ?></td>
+            <td><?php print($order_detail['price']); ?></td>
+            <td><?php print($order_detail['quantity']); ?></td>
+            <td><?php print($order_detail['price'] * $order_detail['quantity']); ?>円</td>
+          </tr>
+          <?php } ?>
+        </tbody>
+      </table>
+    <?php } else { ?>
+      <p>注文詳細はありません。</p>
+    <?php } ?> 
+  </div>
+</body>
+</html>

--- a/www/view/order_view.php
+++ b/www/view/order_view.php
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <?php include VIEW_PATH . 'templates/head.php'; ?>
+  <title>注文履歴</title>
+</head>
+<body>
+  <?php include VIEW_PATH . 'templates/header_logined.php'; ?>
+  <h1>注文履歴</h1>
+  <div class="container">
+
+    <?php include VIEW_PATH . 'templates/messages.php'; ?>
+
+    <?php if(count($orders) > 0){ ?>    
+      <table class="table table-bordered">
+        <thead class="thead-light">
+          <tr>
+            <th>注文番号</th>
+            <th>購入日時</th>
+            <th>該当の注文の合計金額</th>
+            <th>操作</th>
+          </tr>
+        </thead>
+        <tbody>
+          <?php foreach($orders as $order){ ?>
+          <tr>
+            <td><?php print($order['order_id']); ?></td>
+            <td><?php print($order['created']); ?></td>
+            <td><?php print(number_format($total_price[$order['order_id']])); ?>円</td>
+            <td>
+              <form method="post" action="order_detail.php">
+                <input type="submit" value="明細表示" class="btn btn-primary">
+                <input type="hidden" name="order_id" value="<?php print($order['order_id']); ?>">
+                <input type="hidden" name="created" value="<?php print($order['created']); ?>">
+                <input type="hidden" name="total_price" value="<?php print($total_price[$order['order_id']]); ?>">
+                <input type="hidden" name="token" value="<?php print ($token);?>">
+              </form>
+            </td>
+          </tr>
+          <?php } ?>
+        </tbody>
+      </table>
+    <?php } else { ?>
+      <p>注文履歴はありません。</p>
+    <?php } ?> 
+  </div>
+</body>
+</html>

--- a/www/view/templates/header_logined.php
+++ b/www/view/templates/header_logined.php
@@ -10,6 +10,9 @@
           <a class="nav-link" href="<?php print(CART_URL);?>">カート</a>
         </li>
         <li class="nav-item">
+          <a class="nav-link" href="<?php print(ORDER_URL);?>">注文履歴</a>
+        </li>
+        <li class="nav-item">
           <a class="nav-link" href="<?php print(LOGOUT_URL);?>">ログアウト</a>
         </li>
         <?php if(is_admin($user)){ ?>


### PR DESCRIPTION
課題2-3の注文履歴および注文詳細を表示する画面を追加いたしました。

またサインアップが正しく動作しない不具合があったため修正致しました。
(以前の課題1-2でmodel/user.php内のexecute_query()の引数について修正漏れがあったため、その部分を修正しました。)

お手数をお掛け致しますが、確認をよろしくお願い致します！

#14 

